### PR TITLE
Add Intrinsic - MaterialIcon

### DIFF
--- a/packages/intrinsics/src/lib/components/MaterialIcon/index.tsx
+++ b/packages/intrinsics/src/lib/components/MaterialIcon/index.tsx
@@ -1,0 +1,38 @@
+import { createBitComponent } from "../../Polymorphism";
+import { useStylesheet } from "../../hooks/useStylesheet";
+import classNames from "../../classnames";
+
+import "./style.scss";
+
+const sheets = {
+    "normal": "https://fonts.googleapis.com/icon?family=Material+Icons",
+    "outline": "https://fonts.googleapis.com/icon?family=Material+Icons+Outlined",
+    "round": "https://fonts.googleapis.com/icon?family=Material+Icons+Round",
+    "twotone": "https://fonts.googleapis.com/icon?family=Material+Icons+Two+Tone",
+    "sharp": "https://fonts.googleapis.com/icon?family=Material+Icons+Sharp"
+};
+
+export type IconVariant = "normal" | "outline" | "round" | "twotone" | "sharp";
+
+export type Props = {
+    variant?: IconVariant;
+    icon: string;
+};
+
+export default createBitComponent<Props, "i">("MaterialIcon", ({
+    as,
+    variant = "normal",
+    className,
+    icon,
+    ...props
+}, ref) => {
+    useStylesheet(sheets[variant]);
+
+    const Component = as || "i";
+
+    return (
+        <Component {...props} ref={ref}
+            className={classNames("material-icon", `variant-${variant}`, className)}
+            children={icon} />
+    );
+});

--- a/packages/intrinsics/src/lib/components/MaterialIcon/style.scss
+++ b/packages/intrinsics/src/lib/components/MaterialIcon/style.scss
@@ -1,0 +1,23 @@
+.material-icon {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    // font-size: 1.5rem;
+    // line-height: 1;
+    // display: inline-block;
+    // color: inherit;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
+    white-space: nowrap;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    -moz-osx-font-smoothing: grayscale;
+    font-feature-settings: 'liga';
+
+    &.variant-outline { font-family: 'Material Icons Outlined'; }
+    &.variant-round   { font-family: 'Material Icons Round';    }
+    &.variant-twotone { font-family: 'Material Icons Two Tone'; }
+    &.variant-sharp   { font-family: 'Material Icons Sharp';    }
+}

--- a/packages/intrinsics/src/lib/hooks/useStylesheet.ts
+++ b/packages/intrinsics/src/lib/hooks/useStylesheet.ts
@@ -1,0 +1,28 @@
+import React from "react";
+
+let cache: Record<string, HTMLLinkElement> = {};
+
+export const useStylesheet = (url: string) => {
+    React.useEffect(() => {
+        let elem = cache[url];
+
+        if(!elem) {
+            elem = document.createElement("link");
+            elem.rel = "stylesheet";
+            elem.href = url;
+
+            document.head.appendChild(elem);
+            cache[url] = elem;
+        }
+
+        //? Commented out to keep stylesheet links in head, better perf w/ toggle buttons
+        // return () => {
+        //     if(document.head.contains(elem) && cache[url]) {
+        //         elem.remove();
+        //         delete cache[url];
+        //     }
+        // };
+    }, [ url ]);
+};
+
+export default useStylesheet;

--- a/packages/intrinsics/src/lib/index.ts
+++ b/packages/intrinsics/src/lib/index.ts
@@ -1,3 +1,4 @@
 export { default as Divider } from "./components/Divider";
+export { default as MaterialIcon } from "./components/MaterialIcon";
 export { default as Panel } from "./components/Panel";
 export { default as Shape } from "./components/Shape";


### PR DESCRIPTION
## Description

Google's Material Icons webfont is easy to setup and provides a helpful palette of icons for developers. This component allows opt-in access to each of the different available styles, with a built-in mechanism to download the required stylesheet as-needed.

This component supports the following unique props:

```ts
type IconVariant = "normal" | "outline" | "round" | "twotone" | "sharp";

type Props = {
    variant?: IconVariant;
    icon: string;
};
```

## Example Use

```jsx
<MaterialIcon icon="home" />
```

```jsx
<MaterialIcon variant="twotone" icon="face" />
```

## Changes

- Add `useStylesheet` hook
- Add `MaterialIcon` component