### PR TITLE
Improve .d.ts typing

### DIFF
--- a/packages/intrinsics/src/lib/Polymorphism.ts
+++ b/packages/intrinsics/src/lib/Polymorphism.ts
@@ -18,5 +18,5 @@ export type BitComponent<P, T extends ElementType> = <C extends ElementType = T>
  */
 export function createBitComponent<P extends {}, C extends ElementType>(name: string, component: BitComponent<P, C>) {
     Object.defineProperty(component, "name", { writable: false, value: name });
-    return forwardRef(component);
+    return forwardRef(component) as any as BitComponent<P, C>;
 }

--- a/packages/intrinsics/vite.config.ts
+++ b/packages/intrinsics/vite.config.ts
@@ -27,7 +27,12 @@ export default defineConfig({
     plugins: [
         react(),
         npmDist(components),
-        dts({ insertTypesEntry: true }),
+        dts({
+            staticImport: true,
+            skipDiagnostics: false,
+            rollupTypes: true,
+            insertTypesEntry: true
+        }),
         cssSibling(),
         libcss()
     ],


### PR DESCRIPTION
## Context

React's `forwardRef` has some bizarre typing when it comes to generating `.d.ts` files, so we opt to improve the transpiler's options, as well as improving the types it spits out.

## Example Output

Below example is sourced from `dist/components/Divider/index.d.ts`

Before:
```ts
export type Props = {
    vertical?: boolean;
};
declare const _default: import("react").ForwardRefExoticComponent<Omit<import("../../Polymorphism").BitProps<import("react").ElementType<any>, Props>, "ref"> & import("react").RefAttributes<unknown>>;
export default _default;

```

After:

```ts
import type { BitComponent } from '../../Polymorphism';
export type Props = {
    vertical?: boolean;
};
declare const _default: BitComponent<Props, "span">;
export default _default;
```